### PR TITLE
fix: disable vercel optimization on homepage celeb images

### DIFF
--- a/main-site/lib/CelebGallery.tsx
+++ b/main-site/lib/CelebGallery.tsx
@@ -13,8 +13,9 @@ export const CelebGallery: React.FC<{
 }> = (props) => {
   return (
     <div className={c('flex flex-wrap justify-center', props.className)}>
-      {props.celebGalleryItems.map((celebData) => {
+      {props.celebGalleryItems.map((celebData, index) => {
         const picture = celebData.picture;
+        const isLCP = index === 0;
 
         return (
           <Link
@@ -36,6 +37,7 @@ export const CelebGallery: React.FC<{
                   key={celebData.slug + '-image'}
                   picture={picture}
                   name={celebData.name}
+                  priority={isLCP}
                 />
 
                 <p className="font-primary absolute bottom-3 left-3 z-10 text-sm font-semibold text-white">

--- a/main-site/lib/CelebImage.tsx
+++ b/main-site/lib/CelebImage.tsx
@@ -20,22 +20,22 @@ export function CelebImage(props: CelebImageProps) {
   const { src, picture: _picture, name, ...rest } = props;
   const picture = _picture || placeholderImage;
 
+  const sanityImageURL = sanityImage(picture)
+    .fit('crop')
+    .crop('top')
+    .width(rest.width || 260)
+    .height(rest.height || 290)
+    .url();
+
   return (
     <Image
-      src={
-        src ||
-        sanityImage(picture)
-          .fit('crop')
-          .crop('top')
-          .width(rest.width || 260)
-          .height(rest.height || 290)
-          .url()
-      }
+      src={src || sanityImageURL}
       layout="responsive"
       width={260}
       height={290}
       objectFit="cover"
       objectPosition="top"
+      unoptimized
       blurDataURL={picture ? picture.metadata.lqip : ''}
       placeholder={picture ? 'blur' : undefined}
       alt={name}


### PR DESCRIPTION
Disables Vercel's image optimization on celebrity images shown on the homepage.

Content on Sanity is already served from their [asset cdn](https://www.sanity.io/docs/asset-cdn) with global nodes. Going through Vercel's CDN again just offers a potentially worse experience (extra hops) at increased running costs.